### PR TITLE
tutee delete request feature added with test

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -46,4 +46,10 @@ class RequestsController < ApplicationController
     end
     redirect_to dashboard_path
   end
+
+  def destroy
+    Request.find_by_id(params[:id]).destroy
+    flash[:success] = "Request deleted."
+    redirect_to dashboard_path
+  end
 end

--- a/app/controllers/tutors_controller.rb
+++ b/app/controllers/tutors_controller.rb
@@ -72,8 +72,11 @@ class TutorsController < ApplicationController
     request_id = params[:request_id]
     tutor_message = params[:tutor_message]
 
-    #Check if request has already been filled since page loaded
-    if Request.find(request_id).matched?
+    #Check if request has been deleted or already been matched by another tutor since page loaded
+    if !Request.exists?(id: request_id)
+      flash[:notice] = "Sorry, this request has been deleted."
+      return redirect_back(fallback_location:"/")
+    elsif Request.find(request_id).matched?
       flash[:notice] = "Sorry, this request has already been matched."
       return redirect_back(fallback_location:"/")
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
     @request  = @user&.requests&.last
     @meeting = @request&.meeting
     @evaluation = @meeting&.evaluation
-    @meeting_time = [["1 hour",1], ["1.5 hours",1.5], ["2 hours",2]]
+    @meeting_time = [["1 hour",1.0], ["1.5 hours",1.5], ["2 hours",2.0]]
     if @request.nil? or @evaluation&.complete? #new account or no active request (all previous fulfilled/closed by admin)
       if !Admin.signups_allowed?
         @status_arr = ['closed','Tutoring signups are closed at this time, please keep an eye on announcements for when they will reopen!']

--- a/app/views/tutees/_table_request.html.haml
+++ b/app/views/tutees/_table_request.html.haml
@@ -15,7 +15,7 @@
     =form_tag request_path(@request.id), method:"put" do
       =render partial:'requests/request_form', locals: {view_only?: false}
       =submit_tag 'Update Request', class: 'btn btn-info form-control'
-
+    =button_to 'Delete Request', request_path(@request), method:"delete", class: 'btn btn-danger form-control'
   -elsif status == 'unscheduled' or status == 'scheduled' #view request and meeting details only
     =render partial:'requests/request_form', locals: {view_only?: true}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   delete '/delete_meeting' => 'tutors#delete_meeting', as: :tutor_delete_meeting
   post '/switch_views' => 'tutors#switch_views', as: :tutor_switch_views
   ##REQUESTS
-  resources :requests, only: [:create, :update]
+  resources :requests, only: [:create, :update, :destroy]
 
   ##EVALUATIONS
   resources :evaluations, only: [:update]

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,27 +14,27 @@
       <img src="./assets/0.10.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" style="display:none;">
-      <div class="timestamp">Generated <abbr class="timeago" title="2021-09-24T10:13:55-07:00">2021-09-24T10:13:55-07:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2021-09-24T11:22:06-07:00">2021-09-24T11:22:06-07:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
         <div class="file_list_container" id="AllFiles">
   <h2>
     <span class="group_name">All Files</span>
-    (<span class="covered_percent"><span class="yellow">82.78%</span></span>
+    (<span class="covered_percent"><span class="yellow">82.68%</span></span>
      covered at
      <span class="covered_strength">
        <span class="green">
-         6.94
+         7.07
        </span>
     </span> hits/line)
   </h2>
   <a name="AllFiles"></a>
   <div>
     <b>59</b> files in total.
-    <b>836</b> relevant lines. 
-    <span class="green"><b>692</b> lines covered</span> and
-    <span class="red"><b>144</b> lines missed </span>
+    <b>843</b> relevant lines. 
+    <span class="green"><b>697</b> lines covered</span> and
+    <span class="red"><b>146</b> lines missed </span>
   </div>
   <table class="file_list">
     <thead>
@@ -67,7 +67,7 @@
         <td>16</td>
         <td>13</td>
         <td>3</td>
-        <td>15.8</td>
+        <td>16.8</td>
       </tr>
       
       <tr>
@@ -92,22 +92,22 @@
       
       <tr>
         <td class="strong"><a href="#f9980925f24079fd371b31374e65a78944dd0a13" class="src_link" title="app/controllers/requests_controller.rb">app/controllers/requests_controller.rb</a></td>
-        <td class="red strong">50.0 %</td>
-        <td>49</td>
-        <td>32</td>
+        <td class="red strong">55.56 %</td>
+        <td>55</td>
+        <td>36</td>
+        <td>20</td>
         <td>16</td>
-        <td>16</td>
-        <td>1.7</td>
+        <td>1.6</td>
       </tr>
       
       <tr>
         <td class="strong"><a href="#7e7531a098cdf3b3bb7761b75688f1373fc51a28" class="src_link" title="app/controllers/tutors_controller.rb">app/controllers/tutors_controller.rb</a></td>
-        <td class="red strong">75.36 %</td>
-        <td>110</td>
-        <td>69</td>
-        <td>52</td>
-        <td>17</td>
-        <td>3.2</td>
+        <td class="red strong">73.61 %</td>
+        <td>113</td>
+        <td>72</td>
+        <td>53</td>
+        <td>19</td>
+        <td>3.1</td>
       </tr>
       
       <tr>
@@ -127,7 +127,7 @@
         <td>49</td>
         <td>47</td>
         <td>2</td>
-        <td>14.1</td>
+        <td>14.8</td>
       </tr>
       
       <tr>
@@ -227,7 +227,7 @@
         <td>25</td>
         <td>25</td>
         <td>0</td>
-        <td>37.8</td>
+        <td>38.8</td>
       </tr>
       
       <tr>
@@ -247,7 +247,7 @@
         <td>16</td>
         <td>13</td>
         <td>3</td>
-        <td>1.4</td>
+        <td>1.5</td>
       </tr>
       
       <tr>
@@ -257,7 +257,7 @@
         <td>14</td>
         <td>14</td>
         <td>0</td>
-        <td>21.9</td>
+        <td>22.7</td>
       </tr>
       
       <tr>
@@ -287,7 +287,7 @@
         <td>17</td>
         <td>16</td>
         <td>1</td>
-        <td>25.1</td>
+        <td>25.8</td>
       </tr>
       
       <tr>
@@ -317,7 +317,7 @@
         <td>21</td>
         <td>21</td>
         <td>0</td>
-        <td>15.4</td>
+        <td>16.0</td>
       </tr>
       
       <tr>
@@ -517,7 +517,7 @@
         <td>89</td>
         <td>65</td>
         <td>24</td>
-        <td>9.4</td>
+        <td>9.7</td>
       </tr>
       
       <tr>
@@ -557,7 +557,7 @@
         <td>9</td>
         <td>9</td>
         <td>0</td>
-        <td>11.7</td>
+        <td>12.6</td>
       </tr>
       
       <tr>
@@ -577,7 +577,7 @@
         <td>3</td>
         <td>3</td>
         <td>0</td>
-        <td>24.3</td>
+        <td>25.0</td>
       </tr>
       
       <tr>
@@ -587,7 +587,7 @@
         <td>25</td>
         <td>12</td>
         <td>13</td>
-        <td>7.5</td>
+        <td>7.6</td>
       </tr>
       
       <tr>
@@ -1721,8 +1721,8 @@
           <code class="ruby">  def configure_permitted_parameters</code>
         </li>
       
-        <li class="covered" data-hits="95" data-linenumber="9">
-          <span class="hits">95</span>
+        <li class="covered" data-hits="101" data-linenumber="9">
+          <span class="hits">101</span>
           
           <code class="ruby">    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :email, :gender, :ethnicity,</code>
         </li>
@@ -1733,8 +1733,8 @@
           <code class="ruby">                                                        :major, :dsp, :transfer, :term, :pronoun])</code>
         </li>
       
-        <li class="covered" data-hits="95" data-linenumber="11">
-          <span class="hits">95</span>
+        <li class="covered" data-hits="101" data-linenumber="11">
+          <span class="hits">101</span>
           
           <code class="ruby">    devise_parameter_sanitizer.permit(:account_update, keys: [:email, :first_name, :last_name, :gender, :pronoun, :dsp, :transfer, :major, :password, :password_confirmation, :term, :ethnicity, :major, ethnicity: [], major: []])</code>
         </li>
@@ -1757,14 +1757,14 @@
           <code class="ruby">  def after_sign_in_path_for(resource)</code>
         </li>
       
-        <li class="covered" data-hits="24" data-linenumber="15">
-          <span class="hits">24</span>
+        <li class="covered" data-hits="26" data-linenumber="15">
+          <span class="hits">26</span>
           
           <code class="ruby">    session[:current_user_id] = resource.id</code>
         </li>
       
-        <li class="covered" data-hits="24" data-linenumber="16">
-          <span class="hits">24</span>
+        <li class="covered" data-hits="26" data-linenumber="16">
+          <span class="hits">26</span>
           
           <code class="ruby">    dashboard_path</code>
         </li>
@@ -2241,10 +2241,10 @@
         <div class="source_table" id="f9980925f24079fd371b31374e65a78944dd0a13">
   <div class="header">
     <h3>app/controllers/requests_controller.rb</h3>
-    <h4><span class="red">50.0 %</span> covered</h4>
+    <h4><span class="red">55.56 %</span> covered</h4>
     <div>
-      <b>32</b> relevant lines. 
-      <span class="green"><b>16</b> lines covered</span> and
+      <b>36</b> relevant lines. 
+      <span class="green"><b>20</b> lines covered</span> and
       <span class="red"><b>16</b> lines missed.</span>
     </div>
   </div>
@@ -2543,6 +2543,42 @@
         <li class="never" data-hits="" data-linenumber="49">
           
           
+          <code class="ruby"></code>
+        </li>
+      
+        <li class="covered" data-hits="1" data-linenumber="50">
+          <span class="hits">1</span>
+          
+          <code class="ruby">  def destroy</code>
+        </li>
+      
+        <li class="covered" data-hits="1" data-linenumber="51">
+          <span class="hits">1</span>
+          
+          <code class="ruby">    Request.find_by_id(params[:id]).destroy</code>
+        </li>
+      
+        <li class="covered" data-hits="1" data-linenumber="52">
+          <span class="hits">1</span>
+          
+          <code class="ruby">    flash[:success] = &quot;Request deleted.&quot;</code>
+        </li>
+      
+        <li class="covered" data-hits="1" data-linenumber="53">
+          <span class="hits">1</span>
+          
+          <code class="ruby">    redirect_to dashboard_path</code>
+        </li>
+      
+        <li class="never" data-hits="" data-linenumber="54">
+          
+          
+          <code class="ruby">  end</code>
+        </li>
+      
+        <li class="never" data-hits="" data-linenumber="55">
+          
+          
           <code class="ruby">end</code>
         </li>
       
@@ -2554,11 +2590,11 @@
         <div class="source_table" id="7e7531a098cdf3b3bb7761b75688f1373fc51a28">
   <div class="header">
     <h3>app/controllers/tutors_controller.rb</h3>
-    <h4><span class="red">75.36 %</span> covered</h4>
+    <h4><span class="red">73.61 %</span> covered</h4>
     <div>
-      <b>69</b> relevant lines. 
-      <span class="green"><b>52</b> lines covered</span> and
-      <span class="red"><b>17</b> lines missed.</span>
+      <b>72</b> relevant lines. 
+      <span class="green"><b>53</b> lines covered</span> and
+      <span class="red"><b>19</b> lines missed.</span>
     </div>
   </div>
   
@@ -3012,19 +3048,19 @@
         <li class="never" data-hits="" data-linenumber="75">
           
           
-          <code class="ruby">    #Check if request has already been filled since page loaded</code>
+          <code class="ruby">    #Check if request has been deleted or already been matched by another tutor since page loaded</code>
         </li>
       
         <li class="covered" data-hits="3" data-linenumber="76">
           <span class="hits">3</span>
           
-          <code class="ruby">    if Request.find(request_id).matched?</code>
+          <code class="ruby">    if !Request.exists?(id: request_id)</code>
         </li>
       
         <li class="missed" data-hits="0" data-linenumber="77">
           
           
-          <code class="ruby">      flash[:notice] = &quot;Sorry, this request has already been matched.&quot;</code>
+          <code class="ruby">      flash[:notice] = &quot;Sorry, this request has been deleted.&quot;</code>
         </li>
       
         <li class="missed" data-hits="0" data-linenumber="78">
@@ -3033,193 +3069,211 @@
           <code class="ruby">      return redirect_back(fallback_location:&quot;/&quot;)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="79">
+        <li class="covered" data-hits="3" data-linenumber="79">
+          <span class="hits">3</span>
+          
+          <code class="ruby">    elsif Request.find(request_id).matched?</code>
+        </li>
+      
+        <li class="missed" data-hits="0" data-linenumber="80">
+          
+          
+          <code class="ruby">      flash[:notice] = &quot;Sorry, this request has already been matched.&quot;</code>
+        </li>
+      
+        <li class="missed" data-hits="0" data-linenumber="81">
+          
+          
+          <code class="ruby">      return redirect_back(fallback_location:&quot;/&quot;)</code>
+        </li>
+      
+        <li class="never" data-hits="" data-linenumber="82">
           
           
           <code class="ruby">    end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="80">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="81">
-          <span class="hits">3</span>
-          
-          <code class="ruby">    begin</code>
-        </li>
-      
-        <li class="covered" data-hits="3" data-linenumber="82">
-          <span class="hits">3</span>
-          
-          <code class="ruby">      TutorMailer.invite_student(tutor_id, tutee_id, request_id, tutor_message).deliver_now</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="83">
           
           
+          <code class="ruby"></code>
+        </li>
+      
+        <li class="covered" data-hits="3" data-linenumber="84">
+          <span class="hits">3</span>
+          
+          <code class="ruby">    begin</code>
+        </li>
+      
+        <li class="covered" data-hits="3" data-linenumber="85">
+          <span class="hits">3</span>
+          
+          <code class="ruby">      TutorMailer.invite_student(tutor_id, tutee_id, request_id, tutor_message).deliver_now</code>
+        </li>
+      
+        <li class="never" data-hits="" data-linenumber="86">
+          
+          
           <code class="ruby">    rescue StandardError</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="84">
+        <li class="missed" data-hits="0" data-linenumber="87">
           
           
           <code class="ruby">      flash[:notice] = &quot;An error occured when sending out emails.&quot;</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="85">
+        <li class="never" data-hits="" data-linenumber="88">
           
           
           <code class="ruby">    else</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="86">
+        <li class="covered" data-hits="3" data-linenumber="89">
           <span class="hits">3</span>
           
           <code class="ruby">      flash[:success] = &quot;Successfully matched!&quot;</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="87">
+        <li class="covered" data-hits="3" data-linenumber="90">
           <span class="hits">3</span>
           
           <code class="ruby">      Meeting.create!(tutor_id: tutor_id, request_id: request_id, status: &#39;unscheduled&#39;)</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="88">
+        <li class="covered" data-hits="3" data-linenumber="91">
           <span class="hits">3</span>
           
           <code class="ruby">      Request.find(request_id).update(status: &#39;matched&#39;)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="89">
+        <li class="never" data-hits="" data-linenumber="92">
           
           
           <code class="ruby">    end</code>
         </li>
       
-        <li class="covered" data-hits="3" data-linenumber="90">
+        <li class="covered" data-hits="3" data-linenumber="93">
           <span class="hits">3</span>
           
           <code class="ruby">    redirect_back(fallback_location:&quot;/&quot;)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="91">
+        <li class="never" data-hits="" data-linenumber="94">
           
           
           <code class="ruby">  end</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="92">
+        <li class="never" data-hits="" data-linenumber="95">
           
           
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="93">
+        <li class="covered" data-hits="1" data-linenumber="96">
           <span class="hits">1</span>
           
           <code class="ruby">  def total_hours</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="94">
+        <li class="missed" data-hits="0" data-linenumber="97">
           
           
           <code class="ruby">    @tutor= Tutor.find(params[:id])</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="95">
+        <li class="missed" data-hits="0" data-linenumber="98">
           
           
           <code class="ruby">    return Tutor.total_hours_helper(@tutor)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="96">
+        <li class="never" data-hits="" data-linenumber="99">
           
           
           <code class="ruby">  end</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="97">
+        <li class="covered" data-hits="1" data-linenumber="100">
           <span class="hits">1</span>
           
           <code class="ruby">  helper_method :total_hours</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="98">
+        <li class="never" data-hits="" data-linenumber="101">
           
           
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="99">
+        <li class="covered" data-hits="1" data-linenumber="102">
           <span class="hits">1</span>
           
           <code class="ruby">  def hours_this_week</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="100">
+        <li class="missed" data-hits="0" data-linenumber="103">
           
           
           <code class="ruby">    @tutor= Tutor.find(params[:id])</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="101">
+        <li class="missed" data-hits="0" data-linenumber="104">
           
           
           <code class="ruby">    return Tutor.hours_this_week_helper(@tutor)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="102">
+        <li class="never" data-hits="" data-linenumber="105">
           
           
           <code class="ruby">  end</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="103">
+        <li class="covered" data-hits="1" data-linenumber="106">
           <span class="hits">1</span>
           
           <code class="ruby">  helper_method :hours_this_week</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="104">
+        <li class="never" data-hits="" data-linenumber="107">
           
           
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="105">
+        <li class="covered" data-hits="1" data-linenumber="108">
           <span class="hits">1</span>
           
           <code class="ruby">  def average_hours</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="106">
+        <li class="missed" data-hits="0" data-linenumber="109">
           
           
           <code class="ruby">    @tutor= Tutor.find(params[:id])</code>
         </li>
       
-        <li class="missed" data-hits="0" data-linenumber="107">
+        <li class="missed" data-hits="0" data-linenumber="110">
           
           
           <code class="ruby">    return Tutor.average_hours_helper(@tutor)</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="108">
+        <li class="never" data-hits="" data-linenumber="111">
           
           
           <code class="ruby">  end</code>
         </li>
       
-        <li class="covered" data-hits="1" data-linenumber="109">
+        <li class="covered" data-hits="1" data-linenumber="112">
           <span class="hits">1</span>
           
           <code class="ruby">  helper_method :average_hours</code>
         </li>
       
-        <li class="never" data-hits="" data-linenumber="110">
+        <li class="never" data-hits="" data-linenumber="113">
           
           
           <code class="ruby">end</code>
@@ -3857,8 +3911,8 @@
           <code class="ruby">  def show</code>
         </li>
       
-        <li class="covered" data-hits="48" data-linenumber="5">
-          <span class="hits">48</span>
+        <li class="covered" data-hits="51" data-linenumber="5">
+          <span class="hits">51</span>
           
           <code class="ruby">    @user = User.find_by_id(session[:current_user_id])</code>
         </li>
@@ -3869,14 +3923,14 @@
           <code class="ruby">    #tutors get their own dashboard, but also an option to switch between tutee/tutor views</code>
         </li>
       
-        <li class="covered" data-hits="48" data-linenumber="7">
-          <span class="hits">48</span>
+        <li class="covered" data-hits="51" data-linenumber="7">
+          <span class="hits">51</span>
           
           <code class="ruby">    if @user.tutee? or session[:tutor_viewing_tutee]</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="8">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="8">
+          <span class="hits">21</span>
           
           <code class="ruby">      show_tutee_dashboard</code>
         </li>
@@ -3887,8 +3941,8 @@
           <code class="ruby">    else</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="10">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="10">
+          <span class="hits">30</span>
           
           <code class="ruby">      show_tutor_dashboard</code>
         </li>
@@ -3923,38 +3977,38 @@
           <code class="ruby">  def show_tutee_dashboard</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="16">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="16">
+          <span class="hits">21</span>
           
           <code class="ruby">    @request  = @user&amp;.requests&amp;.last</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="17">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="17">
+          <span class="hits">21</span>
           
           <code class="ruby">    @meeting = @request&amp;.meeting</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="18">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="18">
+          <span class="hits">21</span>
           
           <code class="ruby">    @evaluation = @meeting&amp;.evaluation</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="19">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="19">
+          <span class="hits">21</span>
           
-          <code class="ruby">    @meeting_time = [[&quot;1 hour&quot;,1], [&quot;1.5 hours&quot;,1.5], [&quot;2 hours&quot;,2]]</code>
+          <code class="ruby">    @meeting_time = [[&quot;1 hour&quot;,1.0], [&quot;1.5 hours&quot;,1.5], [&quot;2 hours&quot;,2.0]]</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="20">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="20">
+          <span class="hits">21</span>
           
           <code class="ruby">    if @request.nil? or @evaluation&amp;.complete? #new account or no active request (all previous fulfilled/closed by admin)</code>
         </li>
       
-        <li class="covered" data-hits="9" data-linenumber="21">
-          <span class="hits">9</span>
+        <li class="covered" data-hits="10" data-linenumber="21">
+          <span class="hits">10</span>
           
           <code class="ruby">      if !Admin.signups_allowed?</code>
         </li>
@@ -3971,8 +4025,8 @@
           <code class="ruby">      else</code>
         </li>
       
-        <li class="covered" data-hits="8" data-linenumber="24">
-          <span class="hits">8</span>
+        <li class="covered" data-hits="9" data-linenumber="24">
+          <span class="hits">9</span>
           
           <code class="ruby">        @status_arr = [&#39;none&#39;,&#39;No request pending.&#39;]</code>
         </li>
@@ -3983,8 +4037,8 @@
           <code class="ruby">      end</code>
         </li>
       
-        <li class="covered" data-hits="10" data-linenumber="26">
-          <span class="hits">10</span>
+        <li class="covered" data-hits="11" data-linenumber="26">
+          <span class="hits">11</span>
           
           <code class="ruby">    elsif @request&amp;.closed_by_admin?</code>
         </li>
@@ -3995,14 +4049,14 @@
           <code class="ruby">      @status_arr = [&#39;none&#39;,&#39;Your request was closed by admin, please submit a new request.&#39;]</code>
         </li>
       
-        <li class="covered" data-hits="9" data-linenumber="28">
-          <span class="hits">9</span>
+        <li class="covered" data-hits="10" data-linenumber="28">
+          <span class="hits">10</span>
           
           <code class="ruby">    elsif @request.open?                                 #most recent request is still open</code>
         </li>
       
-        <li class="covered" data-hits="6" data-linenumber="29">
-          <span class="hits">6</span>
+        <li class="covered" data-hits="7" data-linenumber="29">
+          <span class="hits">7</span>
           
           <code class="ruby">      @status_arr = [&#39;open&#39;,&#39;Request submitted&#39;]</code>
         </li>
@@ -4103,14 +4157,14 @@
           <code class="ruby">    end</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="46">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="46">
+          <span class="hits">21</span>
           
           <code class="ruby">    @course_array = Admin.course_list</code>
         </li>
       
-        <li class="covered" data-hits="19" data-linenumber="47">
-          <span class="hits">19</span>
+        <li class="covered" data-hits="21" data-linenumber="47">
+          <span class="hits">21</span>
           
           <code class="ruby">    @previous_requests = Request.where(user_id: @user.id)</code>
         </li>
@@ -4133,38 +4187,38 @@
           <code class="ruby">  def show_tutor_dashboard</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="51">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="51">
+          <span class="hits">30</span>
           
           <code class="ruby">    @meetings = Meeting.where(&quot;tutor_id = ? AND status != &#39;finished&#39;&quot;, @user.id)</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="52">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="52">
+          <span class="hits">30</span>
           
           <code class="ruby">    @previous_meetings = Meeting.where(&quot;tutor_id = ? AND status = &#39;finished&#39;&quot;, @user.id)</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="53">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="53">
+          <span class="hits">30</span>
           
           <code class="ruby">    @my_hours_total = @user.evaluations.where(&quot;took_place = true&quot;).pluck(:hours).sum</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="54">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="54">
+          <span class="hits">30</span>
           
           <code class="ruby">    @my_hours_week = @user.evaluations.where(&quot;evaluations.created_at &gt; ? and took_place = true&quot;, Time.now-7.days).pluck(:hours).sum</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="55">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="55">
+          <span class="hits">30</span>
           
           <code class="ruby">    @class_hours_total = Evaluation.where(&quot;took_place = true&quot;).pluck(:hours).sum</code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="56">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="56">
+          <span class="hits">30</span>
           
           <code class="ruby">    @class_hours_week = Evaluation.where(&quot;evaluations.created_at &gt; ? and took_place = true&quot;, Time.now-7.days).pluck(:hours).sum</code>
         </li>
@@ -4175,14 +4229,14 @@
           <code class="ruby"></code>
         </li>
       
-        <li class="covered" data-hits="29" data-linenumber="58">
-          <span class="hits">29</span>
+        <li class="covered" data-hits="30" data-linenumber="58">
+          <span class="hits">30</span>
           
           <code class="ruby">    average_ratings = @user.questions.where(question_template_id: QuestionTemplate.where(question_type: &#39;scale&#39;, is_active:true).ids, is_admin_only: false).group(&#39;question_template_id&#39;).average(&quot;CAST(response AS INTEGER)&quot;)</code>
         </li>
       
-        <li class="covered" data-hits="45" data-linenumber="59">
-          <span class="hits">45</span>
+        <li class="covered" data-hits="46" data-linenumber="59">
+          <span class="hits">46</span>
           
           <code class="ruby">    @questions = average_ratings.map{ |k,v| [QuestionTemplate.find(k),v]}</code>
         </li>
@@ -4761,8 +4815,8 @@
           <code class="ruby">      # All admins access/modify the same row</code>
         </li>
       
-        <li class="covered" data-hits="261" data-linenumber="7">
-          <span class="hits">261</span>
+        <li class="covered" data-hits="266" data-linenumber="7">
+          <span class="hits">266</span>
           
           <code class="ruby">      return 1</code>
         </li>
@@ -4785,8 +4839,8 @@
           <code class="ruby">    def course_list</code>
         </li>
       
-        <li class="covered" data-hits="96" data-linenumber="11">
-          <span class="hits">96</span>
+        <li class="covered" data-hits="100" data-linenumber="11">
+          <span class="hits">100</span>
           
           <code class="ruby">      self.find_by_id(master_admin_index).course_list</code>
         </li>
@@ -4953,8 +5007,8 @@
           <code class="ruby">    def signups_allowed?</code>
         </li>
       
-        <li class="covered" data-hits="36" data-linenumber="39">
-          <span class="hits">36</span>
+        <li class="covered" data-hits="37" data-linenumber="39">
+          <span class="hits">37</span>
           
           <code class="ruby">      self.find_by_id(master_admin_index).signups_allowed</code>
         </li>
@@ -4989,8 +5043,8 @@
           <code class="ruby">    def general_seed_password</code>
         </li>
       
-        <li class="covered" data-hits="486" data-linenumber="45">
-          <span class="hits">486</span>
+        <li class="covered" data-hits="499" data-linenumber="45">
+          <span class="hits">499</span>
           
           <code class="ruby">      &#39;111111&#39;</code>
         </li>
@@ -5231,8 +5285,8 @@
           <code class="ruby">  def complete?</code>
         </li>
       
-        <li class="covered" data-hits="9" data-linenumber="28">
-          <span class="hits">9</span>
+        <li class="covered" data-hits="10" data-linenumber="28">
+          <span class="hits">10</span>
           
           <code class="ruby">    self.status == &quot;complete&quot;</code>
         </li>
@@ -5298,8 +5352,8 @@
           <code class="ruby">  def tutor</code>
         </li>
       
-        <li class="covered" data-hits="47" data-linenumber="5">
-          <span class="hits">47</span>
+        <li class="covered" data-hits="55" data-linenumber="5">
+          <span class="hits">55</span>
           
           <code class="ruby">    Tutor.find_by_id(self.tutor_id)</code>
         </li>
@@ -5322,8 +5376,8 @@
           <code class="ruby">  def request</code>
         </li>
       
-        <li class="covered" data-hits="218" data-linenumber="9">
-          <span class="hits">218</span>
+        <li class="covered" data-hits="221" data-linenumber="9">
+          <span class="hits">221</span>
           
           <code class="ruby">    Request.find_by_id(self.request_id)</code>
         </li>
@@ -5781,8 +5835,8 @@
           <code class="ruby">  def open?</code>
         </li>
       
-        <li class="covered" data-hits="9" data-linenumber="13">
-          <span class="hits">9</span>
+        <li class="covered" data-hits="10" data-linenumber="13">
+          <span class="hits">10</span>
           
           <code class="ruby">    self.status == &#39;open&#39;</code>
         </li>
@@ -5829,8 +5883,8 @@
           <code class="ruby">  def closed_by_admin?</code>
         </li>
       
-        <li class="covered" data-hits="10" data-linenumber="21">
-          <span class="hits">10</span>
+        <li class="covered" data-hits="11" data-linenumber="21">
+          <span class="hits">11</span>
           
           <code class="ruby">    self.status == &#39;closed by admin&#39;</code>
         </li>
@@ -5853,8 +5907,8 @@
           <code class="ruby">  def self.get_open_requests_by_course course</code>
         </li>
       
-        <li class="covered" data-hits="321" data-linenumber="25">
-          <span class="hits">321</span>
+        <li class="covered" data-hits="331" data-linenumber="25">
+          <span class="hits">331</span>
           
           <code class="ruby">    Request.where(course: course, status: &quot;open&quot;)</code>
         </li>
@@ -6138,8 +6192,8 @@
           <code class="ruby">  def full_name</code>
         </li>
       
-        <li class="covered" data-hits="132" data-linenumber="23">
-          <span class="hits">132</span>
+        <li class="covered" data-hits="136" data-linenumber="23">
+          <span class="hits">136</span>
           
           <code class="ruby">    self.first_name + &#39; &#39; + self.last_name</code>
         </li>
@@ -6162,8 +6216,8 @@
           <code class="ruby">  def tutor?</code>
         </li>
       
-        <li class="covered" data-hits="77" data-linenumber="27">
-          <span class="hits">77</span>
+        <li class="covered" data-hits="81" data-linenumber="27">
+          <span class="hits">81</span>
           
           <code class="ruby">    type == &#39;Tutor&#39;</code>
         </li>
@@ -6186,8 +6240,8 @@
           <code class="ruby">  def tutee?</code>
         </li>
       
-        <li class="covered" data-hits="96" data-linenumber="31">
-          <span class="hits">96</span>
+        <li class="covered" data-hits="102" data-linenumber="31">
+          <span class="hits">102</span>
           
           <code class="ruby">    type == &#39;Tutee&#39;</code>
         </li>
@@ -9703,7 +9757,7 @@
         <li class="covered" data-hits="1" data-linenumber="17">
           <span class="hits">1</span>
           
-          <code class="ruby">  resources :requests, only: [:create, :update]</code>
+          <code class="ruby">  resources :requests, only: [:create, :update, :destroy]</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="18">
@@ -11336,8 +11390,8 @@
           <code class="ruby">Given /^(?:|I )am on (.+)$/ do |page_name|</code>
         </li>
       
-        <li class="covered" data-hits="37" data-linenumber="42">
-          <span class="hits">37</span>
+        <li class="covered" data-hits="39" data-linenumber="42">
+          <span class="hits">39</span>
           
           <code class="ruby">  visit path_to(page_name)</code>
         </li>
@@ -11426,8 +11480,8 @@
           <code class="ruby">When /I click on &quot;(.*)&quot; link/ do |link|</code>
         </li>
       
-        <li class="covered" data-hits="13" data-linenumber="57">
-          <span class="hits">13</span>
+        <li class="covered" data-hits="18" data-linenumber="57">
+          <span class="hits">18</span>
           
           <code class="ruby">  click_link(link)</code>
         </li>
@@ -11498,8 +11552,8 @@
           <code class="ruby">Then(/^I should see &quot;(.*?)&quot;$/) do |arg1|</code>
         </li>
       
-        <li class="covered" data-hits="144" data-linenumber="69">
-          <span class="hits">144</span>
+        <li class="covered" data-hits="150" data-linenumber="69">
+          <span class="hits">150</span>
           
           <code class="ruby">  page.should have_content(&quot;#{arg1}&quot;)</code>
         </li>
@@ -11522,8 +11576,8 @@
           <code class="ruby">Then(/^I should see button &quot;(.*?)&quot;$/) do |arg1|</code>
         </li>
       
-        <li class="covered" data-hits="4" data-linenumber="73">
-          <span class="hits">4</span>
+        <li class="covered" data-hits="5" data-linenumber="73">
+          <span class="hits">5</span>
           
           <code class="ruby">  page.should have_button(&quot;#{arg1}&quot;)</code>
         </li>
@@ -11546,14 +11600,14 @@
           <code class="ruby">Then /^(?:|I )should not see &quot;([^&quot;]*)&quot;$/ do |text|</code>
         </li>
       
-        <li class="covered" data-hits="26" data-linenumber="77">
-          <span class="hits">26</span>
+        <li class="covered" data-hits="27" data-linenumber="77">
+          <span class="hits">27</span>
           
           <code class="ruby">  if page.respond_to? :should</code>
         </li>
       
-        <li class="covered" data-hits="26" data-linenumber="78">
-          <span class="hits">26</span>
+        <li class="covered" data-hits="27" data-linenumber="78">
+          <span class="hits">27</span>
           
           <code class="ruby">    page.should have_no_content(text)</code>
         </li>
@@ -11810,8 +11864,8 @@
           <code class="ruby">When /^(?:|I )press &quot;([^&quot;]*)&quot;$/ do |button|</code>
         </li>
       
-        <li class="covered" data-hits="84" data-linenumber="121">
-          <span class="hits">84</span>
+        <li class="covered" data-hits="88" data-linenumber="121">
+          <span class="hits">88</span>
           
           <code class="ruby">  click_button(button)</code>
         </li>
@@ -11858,8 +11912,8 @@
           <code class="ruby">And /^(?:|I )fill in &quot;([^&quot;]*)&quot; with &quot;([^&quot;]*)&quot;$/ do |field, value|</code>
         </li>
       
-        <li class="covered" data-hits="107" data-linenumber="129">
-          <span class="hits">107</span>
+        <li class="covered" data-hits="111" data-linenumber="129">
+          <span class="hits">111</span>
           
           <code class="ruby">  if value == &quot;general_seed_password&quot;</code>
         </li>
@@ -11876,8 +11930,8 @@
           <code class="ruby">  else</code>
         </li>
       
-        <li class="covered" data-hits="106" data-linenumber="132">
-          <span class="hits">106</span>
+        <li class="covered" data-hits="110" data-linenumber="132">
+          <span class="hits">110</span>
           
           <code class="ruby">    fill_in(field, :with =&gt; value)</code>
         </li>
@@ -12396,26 +12450,26 @@
           <code class="ruby">When /I log in with email &quot;(.*)&quot; and password &quot;(.*)&quot;/ do |email,password|</code>
         </li>
       
-        <li class="covered" data-hits="25" data-linenumber="10">
-          <span class="hits">25</span>
+        <li class="covered" data-hits="27" data-linenumber="10">
+          <span class="hits">27</span>
           
           <code class="ruby">  step %{I am on the home page}</code>
         </li>
       
-        <li class="covered" data-hits="25" data-linenumber="11">
-          <span class="hits">25</span>
+        <li class="covered" data-hits="27" data-linenumber="11">
+          <span class="hits">27</span>
           
           <code class="ruby">  step %{I fill in &quot;username&quot; with &quot;#{email}&quot;}</code>
         </li>
       
-        <li class="covered" data-hits="25" data-linenumber="12">
-          <span class="hits">25</span>
+        <li class="covered" data-hits="27" data-linenumber="12">
+          <span class="hits">27</span>
           
           <code class="ruby">  step %{I fill in &quot;password&quot; with &quot;#{password}&quot;}</code>
         </li>
       
-        <li class="covered" data-hits="25" data-linenumber="13">
-          <span class="hits">25</span>
+        <li class="covered" data-hits="27" data-linenumber="13">
+          <span class="hits">27</span>
           
           <code class="ruby">  step %{press &quot;Log in&quot;}</code>
         </li>
@@ -12590,14 +12644,14 @@
           <code class="ruby">  #anything you want to do before every scenario, put it here.</code>
         </li>
       
-        <li class="covered" data-hits="36" data-linenumber="3">
-          <span class="hits">36</span>
+        <li class="covered" data-hits="37" data-linenumber="3">
+          <span class="hits">37</span>
           
           <code class="ruby">  Rails.application.load_seed</code>
         </li>
       
-        <li class="covered" data-hits="36" data-linenumber="4">
-          <span class="hits">36</span>
+        <li class="covered" data-hits="37" data-linenumber="4">
+          <span class="hits">37</span>
           
           <code class="ruby">  puts &quot;db/seeds.rb has been seeded.&quot;</code>
         </li>
@@ -12687,8 +12741,8 @@
           <code class="ruby">  def path_to(page_name)</code>
         </li>
       
-        <li class="covered" data-hits="92" data-linenumber="10">
-          <span class="hits">92</span>
+        <li class="covered" data-hits="94" data-linenumber="10">
+          <span class="hits">94</span>
           
           <code class="ruby">    case page_name</code>
         </li>
@@ -12783,8 +12837,8 @@
           <code class="ruby">    when /^the home\s?page$/</code>
         </li>
       
-        <li class="covered" data-hits="42" data-linenumber="26">
-          <span class="hits">42</span>
+        <li class="covered" data-hits="44" data-linenumber="26">
+          <span class="hits">44</span>
           
           <code class="ruby">      &#39;/&#39;</code>
         </li>

--- a/features/tutee/tutee_delete_request.feature
+++ b/features/tutee/tutee_delete_request.feature
@@ -1,0 +1,29 @@
+@javascript
+Feature: Create tutoring request
+  As a Tutee
+  I want to delete my request
+  When I don't need tutoring
+
+  Background: There exists a tutee with a pending request in CS61B
+    Given I log in with email "tt1@berkeley.edu" and password "111111"
+    Then I should see "Status: Request submitted"
+    And I should see button "Delete Request"
+
+  Scenario: Tutee deletes request and it does not appear for tutors
+    When I click on "Previous Requests" link
+    Then I should see "seeded request tutee 1 - 3"
+    And I should see "open"
+
+    When I click on "Current Request" link
+    And I press "Delete Request"
+    Then I should see "Request deleted."
+    And I should see "Status: No request pending."
+
+    When I click on "Previous Requests" link
+    Then I should not see "seeded request tutee 1 - 3"
+
+    When I press "Log Out"
+    And I log in with email "tr1@berkeley.edu" and password "111111"
+    And I click on "Find Tutees" link
+    And I click on "CS61B" link
+    Then I should see "There are no requests for CS61B at this time."


### PR DESCRIPTION
# Tutee can cancel request prior to matching

## Purpose

The purpose of this Pull Request is to allow tutees to cancel their request prior to matching (when request status is open)

## User Story

- As a tutee
- When I change my mind about receiving tutoring
- Then I should cancel my request

## Changes
request view has delete button that appears when status is open
tutor matching checks for request existence in case it's deleted just before matching
test added as well
corresponding destroy route added for request
fixed minor bug with autofilling time selection for priority tutee

## Pivotal Tracker Links
https://www.pivotaltracker.com/story/show/179704028